### PR TITLE
fix: remove orphaned tests for deleted shouldLoadReleaseAppSupportGhosttyConfig

### DIFF
--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -310,52 +310,6 @@ final class GhosttyConfigTests: XCTestCase {
         )
     }
 
-    func testReleaseAppSupportFallbackLoadsForDebugWhenOnlyReleaseConfigExists() {
-        XCTAssertTrue(
-            GhosttyApp.shouldLoadReleaseAppSupportGhosttyConfig(
-                currentBundleIdentifier: "com.cmuxterm.app.debug",
-                currentConfigFileSize: nil,
-                currentLegacyConfigFileSize: nil,
-                releaseConfigFileSize: 128,
-                releaseLegacyConfigFileSize: nil
-            )
-        )
-    }
-
-    func testReleaseAppSupportFallbackSkipsWhenDebugConfigAlreadyExists() {
-        XCTAssertFalse(
-            GhosttyApp.shouldLoadReleaseAppSupportGhosttyConfig(
-                currentBundleIdentifier: "com.cmuxterm.app.debug.issue-829",
-                currentConfigFileSize: nil,
-                currentLegacyConfigFileSize: 64,
-                releaseConfigFileSize: 128,
-                releaseLegacyConfigFileSize: nil
-            )
-        )
-    }
-
-    func testReleaseAppSupportFallbackSkipsForNonDebugBundleOrMissingReleaseConfig() {
-        XCTAssertFalse(
-            GhosttyApp.shouldLoadReleaseAppSupportGhosttyConfig(
-                currentBundleIdentifier: "com.cmuxterm.app",
-                currentConfigFileSize: nil,
-                currentLegacyConfigFileSize: nil,
-                releaseConfigFileSize: 128,
-                releaseLegacyConfigFileSize: nil
-            )
-        )
-
-        XCTAssertFalse(
-            GhosttyApp.shouldLoadReleaseAppSupportGhosttyConfig(
-                currentBundleIdentifier: "com.cmuxterm.app.debug",
-                currentConfigFileSize: nil,
-                currentLegacyConfigFileSize: nil,
-                releaseConfigFileSize: nil,
-                releaseLegacyConfigFileSize: 0
-            )
-        )
-    }
-
     func testDefaultBackgroundUpdateScopePrioritizesSurfaceOverAppAndUnscoped() {
         XCTAssertTrue(
             GhosttyApp.shouldApplyDefaultBackgroundUpdate(


### PR DESCRIPTION
## Summary
- Remove 3 test functions that reference `GhosttyApp.shouldLoadReleaseAppSupportGhosttyConfig`, which was deleted from Sources
- This fixes the CI build failure affecting all PRs

## Test plan
- [ ] CI passes on this PR
- [ ] PR #9 CI passes after this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)