### PR TITLE
Release v0.62.2-tb8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to cmux are documented here.
 
+## [0.62.2-tb8] - 2026-03-18
+
+### Added
+- Support Emacs-style editing keybindings in TextBox (Ctrl+A/E/F/B/N/P/K/H) ([#9](https://github.com/alumican/cmux-tb/pull/9)) — thanks @kingsalmon1111!
+
+### Thanks to 2 contributors!
+
+- [@alumican](https://github.com/alumican)
+- [@kingsalmon1111](https://github.com/kingsalmon1111)
+
 ## [0.62.2-tb7] - 2026-03-17
 
 ### Added

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -826,7 +826,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 86;
+				CURRENT_PROJECT_VERSION = 87;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -835,7 +835,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.62.2-tb7;
+				MARKETING_VERSION = 0.62.2-tb8;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -865,7 +865,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 86;
+				CURRENT_PROJECT_VERSION = 87;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				GENERATE_INFOPLIST_FILE = NO;
@@ -874,7 +874,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.62.2-tb7;
+				MARKETING_VERSION = 0.62.2-tb8;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -941,10 +941,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 86;
+				CURRENT_PROJECT_VERSION = 87;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.62.2-tb7;
+				MARKETING_VERSION = 0.62.2-tb8;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -958,10 +958,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 86;
+				CURRENT_PROJECT_VERSION = 87;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.62.2-tb7;
+				MARKETING_VERSION = 0.62.2-tb8;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -975,10 +975,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 86;
+				CURRENT_PROJECT_VERSION = 87;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.62.2-tb7;
+				MARKETING_VERSION = 0.62.2-tb8;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -994,10 +994,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 86;
+				CURRENT_PROJECT_VERSION = 87;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.62.2-tb7;
+				MARKETING_VERSION = 0.62.2-tb8;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
## [0.62.2-tb8] - 2026-03-18

### Added
- Support Emacs-style editing keybindings in TextBox (Ctrl+A/E/F/B/N/P/K/H) ([#9](https://github.com/alumican/cmux-tb/pull/9)) — thanks @kingsalmon1111!

### Thanks to 2 contributors!

- [@alumican](https://github.com/alumican)
- [@kingsalmon1111](https://github.com/kingsalmon1111)