### PR TITLE
fix: prevent NSUndoManager SEGV from TextBox teardown and WebView Cmd+Z

### DIFF
--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -102,6 +102,19 @@ enum BrowserImageCopyPasteboardBuilder {
     }
 }
 
+/// True for Cmd+Z (undo) and Cmd+Shift+Z (redo). Used by browser key routing
+/// to keep these out of the app menu's Edit > Undo path, which can crash on a
+/// stale NSUndoManager target left by a previously-deallocated text view. (#16)
+func cmuxIsUndoOrRedoCommandEquivalent(_ event: NSEvent) -> Bool {
+    let flags = event.modifierFlags
+        .intersection(.deviceIndependentFlagsMask)
+        .subtracting([.numericPad, .function, .capsLock])
+    guard flags.contains(.command) else { return false }
+    guard flags.subtracting([.command, .shift]).isEmpty else { return false }
+    let chars = event.charactersIgnoringModifiers?.lowercased()
+    return chars == "z"
+}
+
 /// WKWebView tends to consume some Command-key equivalents (e.g. Cmd+N/Cmd+W),
 /// preventing the app menu/SwiftUI Commands from receiving them. Route app/menu
 /// shortcuts first by default, but allow browser content to try the Find command
@@ -241,6 +254,19 @@ final class CmuxWebView: WKWebView {
         // Menu/app shortcut routing is only needed for Command equivalents
         // (New Tab, Close Tab, tab switching, split commands, etc).
         guard flags.contains(.command) else {
+            let result = super.performKeyEquivalent(with: event)
+#if DEBUG
+            handled = result
+#endif
+            return result
+        }
+
+        // Cmd+Z / Cmd+Shift+Z must go to WebKit for web content undo/redo,
+        // not through NSApp.mainMenu's Edit > Undo. The app menu's undo:
+        // walks the responder chain and can invoke a stale text undo target
+        // left over from an old TextBox text view, causing a use-after-free
+        // crash inside NSUndoManager.undoNestedGroup. (#16)
+        if cmuxIsUndoOrRedoCommandEquivalent(event) {
             let result = super.performKeyEquivalent(with: event)
 #if DEBUG
             handled = result

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -976,13 +976,15 @@ struct TextBoxInputView: NSViewRepresentable {
     }
 
     /// Clear undo operations targeting this text view before SwiftUI tears
-    /// down the representable. The window's NSUndoManager retains targets
-    /// registered by NSTextView (allowsUndo); without cleanup a later Cmd+Z
-    /// can invoke `_undoRedoTextOperation:` on the deallocated view. (#16)
+    /// down the representable. The text view's allowsUndo registers actions
+    /// whose target is the text view itself; if the underlying undo manager
+    /// is shared via the responder chain (or anything outlives the text
+    /// view), a later Cmd+Z can invoke `_undoRedoTextOperation:` on the
+    /// deallocated view. Sweep self off every reachable undo manager. (#16)
     static func dismantleNSView(_ container: NSView, coordinator: Coordinator) {
         guard let scrollView = container.subviews.first as? NSScrollView,
               let textView = scrollView.documentView as? InputTextView else { return }
-        textView.undoManager?.removeAllActions(withTarget: textView)
+        textView.purgeUndoActionsTargetingSelf()
     }
 
     // MARK: Coordinator
@@ -1088,6 +1090,48 @@ final class InputTextView: NSTextView {
     /// dismantleNSView path, ensure no dangling undo targets remain. (#16)
     deinit {
         undoManager?.removeAllActions(withTarget: self)
+    }
+
+    /// Called by AppKit before the view is moved out of (or into) a window.
+    /// When the view is leaving its current window, the responder chain is
+    /// still intact and any undo manager that registered actions for self
+    /// is still reachable. Sweep them now; once the view is detached the
+    /// chain lookup returns nil and cleanup at deinit is a no-op. (#16)
+    override func viewWillMove(toWindow newWindow: NSWindow?) {
+        if newWindow !== window {
+            purgeUndoActionsTargetingSelf()
+        }
+        super.viewWillMove(toWindow: newWindow)
+    }
+
+    /// Remove every undo action whose target is this text view from any
+    /// undo manager reachable via the responder chain (self, window,
+    /// next responders). NSTextView with allowsUndo may register actions
+    /// against the text view in either its own private manager or one
+    /// supplied by the responder chain depending on the host; sweeping
+    /// every reachable manager makes the cleanup independent of that
+    /// detail. (#16)
+    func purgeUndoActionsTargetingSelf() {
+        undoManager?.removeAllActions(withTarget: self)
+        var seen = Set<ObjectIdentifier>()
+        if let mine = undoManager {
+            seen.insert(ObjectIdentifier(mine))
+        }
+        var responder: NSResponder? = self
+        var hops = 0
+        while let current = responder, hops < 32 {
+            if let manager = current.undoManager,
+               !seen.contains(ObjectIdentifier(manager)) {
+                seen.insert(ObjectIdentifier(manager))
+                manager.removeAllActions(withTarget: self)
+            }
+            responder = current.nextResponder
+            hops += 1
+        }
+        if let windowManager = window?.undoManager,
+           !seen.contains(ObjectIdentifier(windowManager)) {
+            windowManager.removeAllActions(withTarget: self)
+        }
     }
 
     /// Set by keyDown when a key event was already forwarded to the terminal,


### PR DESCRIPTION
## Summary
- TextBox teardown のクリーンアップが detach 後の `self.undoManager` 解決失敗で空振りしていたため、レスポンダーチェーン上の全 NSUndoManager から self を target とするアクションを `viewWillMove(toWindow:)` で proactive に sweep
- CmuxWebView の Cmd+Z / Cmd+Shift+Z を `NSApp.mainMenu` (Edit > Undo) 経由ではなく `super.performKeyEquivalent` (WebKit ネイティブ) に委譲し、ダングリング text-undo target への到達経路自体を遮断

Fixes #16.

## tb14 (commit 909566c5e) の修正で塞げていなかった理由
tb14 では `dismantleNSView` と `deinit` の両方で `textView.undoManager?.removeAllActions(withTarget: textView)` を呼んでいたが、実際には bug を塞ぎきれていなかった:

| tb14 のコード | 実際の効果 |
|---|---|
| `dismantleNSView` での sweep | 部分的に効くが、`textView.undoManager` が解決するのは「self が現在見えている manager」だけで、responder chain 上位や window 提供の manager に残ったアクションは取り逃がす |
| `deinit` での sweep | ほぼ no-op。deinit 時には view は既に window から外れていて responder chain が切れているため `undoManager` 解決が nil になり、何もしない |

このPRでは:
- `dismantleNSView` は残し、sweep を広げた `purgeUndoActionsTargetingSelf()` を呼ぶように差し替え(`self.undoManager` → responder chain → `window.undoManager` を ObjectIdentifier で dedupe しつつ全部 sweep)
- `deinit` は三重の安全網として残す
- **`viewWillMove(toWindow:)` を新規追加** — detach 直前で responder chain が生きてる時点で sweep する。これが実際に効く本命の hook

加えて、AI分析コメントで指摘された **WebView 焦点時の Cmd+Z** 経路を `CmuxWebView.performKeyEquivalent` で早期に super 委譲することで、TextBox 系の cleanup を完全に行えなかった場合の保険にもなる(menu Undo に届かないので dangling target に触れ得ない)。

## Test plan
- [x] Debug ビルド成功 (`./scripts/reload.sh --tag fix-undo-segv --launch`)
- [x] TextBox 入力 → タブ切替 → 戻る → Cmd+Z でクラッシュしないことを実機で確認
- [ ] 内蔵ブラウザ (Notion 等) で編集中 → Cmd+Z でクラッシュしないことを実機で確認
- [ ] 通常の TextBox 内 undo / redo が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)