### PR TITLE
fix: isolate TextBox undo into a Coordinator-owned UndoManager

### DIFF
--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -994,8 +994,22 @@ struct TextBoxInputView: NSViewRepresentable {
         weak var textView: NSTextView?
         weak var container: NSView?
 
+        /// Coordinator-owned NSUndoManager returned from
+        /// `undoManager(for:)`. This decouples NSTextView's undo stack
+        /// from the responder chain / window-level managers — when this
+        /// Coordinator is released (representable dismantle, SwiftUI
+        /// view recreation on tab switch, etc.) ARC tears the manager
+        /// down with the text view, so undo actions registered against
+        /// the text view cannot dangle inside a manager that outlives
+        /// it. (#16)
+        let ownedUndoManager = UndoManager()
+
         init(_ parent: TextBoxInputView) {
             self.parent = parent
+        }
+
+        func undoManager(for view: NSTextView) -> UndoManager? {
+            return ownedUndoManager
         }
 
         func updateBorderOpacity(focused: Bool) {


### PR DESCRIPTION
## Summary
- PR #18 の修正後も発生していたクラッシュ経路を解消: **TextBox に入力 → 別タブ開く → そのタブ閉じる → Cmd+Z** で SEGV
- `TextBoxInputView.Coordinator` に専用 `UndoManager` を持たせ、`undoManager(for view:)` デリゲートで返す → InputTextView の undo スタックを responder chain から完全に切り離し、Coordinator と textView がライフサイクル一致 → ARC で同時破棄 → ダングリング不可能
- PR #18 の `viewWillMove(toWindow:)` / `dismantleNSView` / `deinit` の sweep は冗長化されたが defense-in-depth として残す

Fixes #16 (tb15.1 で再現していた経路).

## なぜ PR #18 では塞げなかったか
PR #18 は textView の `undoManager` プロパティをローカルで sweep するアプローチでした。しかし NSTextView が `allowsUndo = true` で delegate が `undoManager(for:)` を実装していない場合、AppKit は responder chain を辿って **window 等の上位レイヤが持つ NSUndoManager** にアクションを登録します。textView が破棄されても上位 manager はそのまま生き続けるため、dangling target が残存します。`viewWillMove(toWindow:)` での sweep はタブ再生成のような特定タイミングで漏れる経路がありました。

本PRでは **delegate method 経由で Coordinator 所有の UndoManager を強制** することで、undo アクションを「textView と同時に死ぬ」 manager に閉じ込めます。

## Test plan
- [x] Debug ビルド成功 (`./scripts/reload.sh --tag fix-undo-v2 --launch`)
- [x] TextBox に入力 → 別タブ開く → 閉じる → Cmd+Z でクラッシュしないことを実機で確認
- [ ] TextBox 内の通常 undo/redo (Cmd+Z, Cmd+Shift+Z) が動作することを確認
- [ ] IME 入力中の Cmd+Z 挙動を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)